### PR TITLE
Preliminary PR for Render Markdown and nostr URIs on Cards Issue #14

### DIFF
--- a/apps/satshoot/package.json
+++ b/apps/satshoot/package.json
@@ -45,7 +45,9 @@
 		"@scure/bip39": "^1.1.1",
 		"devalue": "^5.0.0",
 		"dexie": "^4.0.2",
+		"dompurify": "^3.1.7",
 		"marked": "^14.1.3",
+		"marked-linkify-it": "^3.1.11",
 		"normalize-url": "^8.0.0",
 		"nostr-tools": "~2.5.2",
 		"svelte-persisted-store": "^0.11.0"

--- a/apps/satshoot/package.json
+++ b/apps/satshoot/package.json
@@ -48,7 +48,6 @@
 		"dexie": "^4.0.2",
 		"dompurify": "^3.1.7",
 		"marked": "^14.1.3",
-		"marked-linkify-it": "^3.1.11",
 		"normalize-url": "^8.0.0",
 		"nostr-tools": "~2.5.2",
 		"svelte-persisted-store": "^0.11.0"

--- a/apps/satshoot/package.json
+++ b/apps/satshoot/package.json
@@ -17,6 +17,7 @@
 		"@sveltejs/vite-plugin-svelte": "^3.0.2",
 		"@tailwindcss/forms": "^0.5.7",
 		"@tailwindcss/typography": "^0.5.10",
+		"@types/dompurify": "^3.0.5",
 		"@types/node": "^20.11.1",
 		"autoprefixer": "^10.4.16",
 		"postcss": "^8.4.33",

--- a/apps/satshoot/package.json
+++ b/apps/satshoot/package.json
@@ -45,6 +45,7 @@
 		"@scure/bip39": "^1.1.1",
 		"devalue": "^5.0.0",
 		"dexie": "^4.0.2",
+		"marked": "^14.1.3",
 		"normalize-url": "^8.0.0",
 		"nostr-tools": "~2.5.2",
 		"svelte-persisted-store": "^0.11.0"

--- a/apps/satshoot/src/lib/components/Cards/Markdown.svelte
+++ b/apps/satshoot/src/lib/components/Cards/Markdown.svelte
@@ -17,15 +17,15 @@
                 const profile = await user.fetchProfile({
                     cacheUsage: NDKSubscriptionCacheUsage.CACHE_FIRST,
                     closeOnEose: true,
-                    groupable: false,
+                    groupable: true,
                     groupableDelay: 1000,
                 });
                 if (profile) {
                     if (profile.name) token.userName = profile.name;
                 }
             } catch (e) {
-				console.log(e);
-			}
+                console.log(e);
+            }
         }
     };
 
@@ -72,15 +72,15 @@
         },
     };
 
+    marked.use({ extensions: [nostrTokenizer], async: true, walkTokens: getPub });
+    marked.use(markedLinkifyIt({}, {}));
     marked.use({
         renderer: {
             image() {
-                return false;
+                return '';
             },
         },
     });
-    marked.use({ extensions: [nostrTokenizer], async: true, walkTokens: getPub });
-    marked.use(markedLinkifyIt({}, {}));
 
     onMount(async () => {
         sanitizedContent = DOMPurify.sanitize(await marked(content));
@@ -88,3 +88,9 @@
 </script>
 
 <div class="markdown">{@html sanitizedContent}</div>
+
+<style>
+    .markdown {
+        padding: 1em;
+    }
+</style>

--- a/apps/satshoot/src/lib/components/Cards/Markdown.svelte
+++ b/apps/satshoot/src/lib/components/Cards/Markdown.svelte
@@ -46,7 +46,7 @@
                 if (user) {
                     token.isNip05 = true;
                     token.tagType = 'npub';
-                    token.content = user.pubkey;
+                    token.content = user.npub;
 
                     // Fetch user profile
                     const profile = await user.fetchProfile({
@@ -142,7 +142,7 @@
             if (token.isNip05) {
                 // Render as Nostr link
                 const { tagType, content, userName } = token;
-                let url = `/${tagType}${content}`;
+                let url = `/${content}`;
                 let linkText = userName ? `@${userName}` : token.text;
                 return `<a href="${url}">${linkText}</a>`;
             } else {

--- a/apps/satshoot/src/lib/components/Cards/Markdown.svelte
+++ b/apps/satshoot/src/lib/components/Cards/Markdown.svelte
@@ -1,18 +1,80 @@
 <script lang="ts">
-	import { marked } from 'marked';
-  
-	export let content = '';
-	
+    import { marked, type Tokens, type TokenizerAndRendererExtension } from 'marked';
+    import markedLinkifyIt from 'marked-linkify-it';
+    import DOMPurify from 'dompurify';
+
+    export let content = '';
+
+    const nostrRegex = /^(nostr:)?n(event|ote|pub|profile|addr)([a-zA-Z0-9]{10,1000})/;
+
+    const nostrTokenizer: TokenizerAndRendererExtension = {
+        name: 'nostr',
+        level: 'inline',
+        start(src: string) {
+            const match = src.match(/(nostr:)?n(event|ote|pub|profile|addr)/);
+            return match ? match.index : -1;
+        },
+        tokenizer(src: string, tokens: any) {
+            const match = nostrRegex.exec(src);
+            if (match) {
+                const [fullMatch, prefix, tagType, content] = match;
+                return {
+                    type: 'nostr',
+                    raw: fullMatch,
+                    text: fullMatch,
+                    tagType: `n${tagType}`,
+                    prefix: prefix || '',
+                    content,
+                    tokens: [],
+                };
+            }
+        },
+        renderer(token: Tokens.Generic) {
+            const { prefix, tagType, content, text } = token;
+
+            // Customize rendering based on the tag type
+            let additionalClass = '';
+            let icon = '';
+
+            switch (tagType) {
+                case 'nevent':
+                    additionalClass = 'nostr-nevent';
+                    icon = '<i class="icon-nevent"></i> ';
+                    break;
+                case 'note':
+                    additionalClass = 'nostr-note';
+                    icon = '<i class="icon-note"></i> ';
+                    break;
+                case 'npub':
+                    additionalClass = 'nostr-npub';
+                    icon = '<i class="icon-npub"></i> ';
+                    break;
+                case 'nprofile':
+                    additionalClass = 'nostr-nprofile';
+                    icon = '<i class="icon-nprofile"></i> ';
+                    break;
+                case 'naddr':
+                    additionalClass = 'nostr-naddr';
+                    icon = '<i class="icon-naddr"></i> ';
+                    break;
+            }
+
+            return `<span class="nostr-handle ${additionalClass}">${token.text}</span>`;
+        },
+    };
+
+    marked.use({
+        renderer: {
+            image() {
+                return false;
+            },
+        },
+    });
+
+    marked.use({ extensions: [nostrTokenizer] });
+    marked.use(markedLinkifyIt({}, {}));
+
+    const sanitizedContent = DOMPurify.sanitize(marked(content));
 </script>
-  
-<div class="markdown">{@html marked(content)}</div>
-  
-<style>
-	.markdown h1 {
-	  font-size: 2em;
-	}
-	.markdown p {
-	  line-height: 1.5;
-	}
-</style>
-  
+
+<div class="markdown">{@html sanitizedContent}</div>

--- a/apps/satshoot/src/lib/components/Cards/Markdown.svelte
+++ b/apps/satshoot/src/lib/components/Cards/Markdown.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import { marked } from 'marked';
+  
+	export let content = '';
+	
+</script>
+  
+<div class="markdown">{@html marked(content)}</div>
+  
+<style>
+	.markdown h1 {
+	  font-size: 2em;
+	}
+	.markdown p {
+	  line-height: 1.5;
+	}
+</style>
+  

--- a/apps/satshoot/src/lib/components/Cards/Markdown.svelte
+++ b/apps/satshoot/src/lib/components/Cards/Markdown.svelte
@@ -12,25 +12,22 @@
 
     const getPub = async (token: Token) => {
         if (token.type === 'nostr') {
+            const id = `${token.tagType}${token.content}`;
+            const { type, data } = nip19.decode(id);
+            let npub = '';
 
-			const id = `${token.tagType}${token.content}`;
-			const {type, data} = nip19.decode(id);
-			let npub = '';
-            
-			switch(type) {
-				case 'nevent':
-                case 'note':
-                case 'naddr':
-					return;
-				case 'nprofile':
-					npub = data.pubkey;
-					break;
-				case 'npub':
-					npub = data;
-					break;
-			}
+            switch (type) {
+                case 'nprofile':
+                    npub = data.pubkey;
+                    break;
+                case 'npub':
+                    npub = data;
+                    break;
+                default:
+                    return;
+            }
 
-			let user = $ndk.getUser({ pubkey: npub });
+            let user = $ndk.getUser({ pubkey: npub });
 
             try {
                 const profile = await user.fetchProfile({
@@ -43,7 +40,7 @@
                     if (profile.name) token.userName = profile.name;
                 }
             } catch (e) {
-                console.log(e);
+                console.error(e);
             }
         }
     };
@@ -79,7 +76,7 @@
                 case 'nevent':
                 case 'note':
                 case 'naddr':
-                    return `<a href="/${tagType}${content}" class="nostr-handle">
+                    return `<a href="/${tagType}${content}">
 					    ${content.slice(0, 10) + '...'}
 					</a>`;
                 case 'nprofile':

--- a/apps/satshoot/src/lib/components/Cards/MessageCard.svelte
+++ b/apps/satshoot/src/lib/components/Cards/MessageCard.svelte
@@ -14,7 +14,9 @@ import { TicketEvent } from "$lib/events/TicketEvent";
 
 import { goto } from "$app/navigation";
 import { page } from '$app/stores';
-    import { selectedPerson } from "$lib/stores/messages";
+import { selectedPerson } from "$lib/stores/messages";
+import Markdown from './Markdown.svelte'
+
 
 export let avatarRight = true;
 export let message: NDKEvent;
@@ -140,7 +142,7 @@ $: if (decryptedDM) {
                     <p class="font-bold text-sm md:text-lg">{name}</p>
                     <small class="opacity-50">{timestamp}</small>
                 </header>
-                <p>{decryptedDM}</p>
+                <Markdown content={decryptedDM} />
                 {#if messageLink && !$page.url.pathname.includes('/messages')}
                     <div class="flex justify-center mr-4">
                         <button

--- a/apps/satshoot/src/lib/components/Cards/OfferCard.svelte
+++ b/apps/satshoot/src/lib/components/Cards/OfferCard.svelte
@@ -37,6 +37,8 @@
     import { wot } from '$lib/stores/wot';
     import TicketIcon from '../Icons/TicketIcon.svelte';
 
+	import Markdown from './Markdown.svelte'
+
     const modalStore = getModalStore();
 
     export let offer: OfferEvent;
@@ -369,7 +371,7 @@
         {/if}
         {#if showDescription}
             <div class="text-center text-base md:text-lg p-2">
-                {offer.description}
+                <Markdown content={offer.description} />
             </div>
         {/if}
         <slot name="takeOffer" />

--- a/apps/satshoot/src/lib/components/Cards/TicketCard.svelte
+++ b/apps/satshoot/src/lib/components/Cards/TicketCard.svelte
@@ -45,6 +45,8 @@
     import { linkifyText } from '$lib/utils/misc';
     import { offerMakerToSelect, selectedPerson } from '$lib/stores/messages';
 
+	import Markdown from './Markdown.svelte'
+
     const modalStore = getModalStore();
 			
     
@@ -253,7 +255,9 @@
     }
 
     onMount(async ()=>{
-        processedDescription = linkifyText(ticket.description);
+
+        //processedDescription = linkifyText(ticket.description);
+		processedDescription = ticket.description;
         if (ticket.acceptedOfferAddress) {
             const winnerOfferEvent = await $ndk.fetchEvent(ticket.acceptedOfferAddress);
             if (winnerOfferEvent) {
@@ -369,7 +373,7 @@
 
         <section class="p-4">
             <div class="text-center text-base md:text-lg break-words whitespace-pre-line">
-                {@html processedDescription }
+                <Markdown content={processedDescription} />
             </div>
 
             <hr class="my-4" />

--- a/apps/satshoot/src/lib/components/Cards/TicketCard.svelte
+++ b/apps/satshoot/src/lib/components/Cards/TicketCard.svelte
@@ -255,8 +255,6 @@
     }
 
     onMount(async ()=>{
-
-		processedDescription = ticket.description;
         if (ticket.acceptedOfferAddress) {
             const winnerOfferEvent = await $ndk.fetchEvent(ticket.acceptedOfferAddress);
             if (winnerOfferEvent) {
@@ -372,7 +370,7 @@
 
         <section class="p-4">
             <div class="text-center text-base md:text-lg break-words whitespace-pre-line">
-                <Markdown content={processedDescription} />
+                <Markdown content={ticket.description} />
             </div>
 
             <hr class="my-4" />

--- a/apps/satshoot/src/lib/components/Cards/TicketCard.svelte
+++ b/apps/satshoot/src/lib/components/Cards/TicketCard.svelte
@@ -256,7 +256,6 @@
 
     onMount(async ()=>{
 
-        //processedDescription = linkifyText(ticket.description);
 		processedDescription = ticket.description;
         if (ticket.acceptedOfferAddress) {
             const winnerOfferEvent = await $ndk.fetchEvent(ticket.acceptedOfferAddress);


### PR DESCRIPTION
This Pull Request addresses the majority of Issue #14:
  - [X] Markdown support to the `TicketCard`, `OfferCard`, `MessageCard` and `UserReviewCard` components with full CSS support
  - [X] Markdown Titles, Lists, URLs etc with the specific exception of Images
  - [X] Shortening of long URLs
  - [X] Support for nostr: URLs, currently `npub` and `naddr`

What needs finalizing:
  - [x] Styling for Markdown - currently inherits the site's CSS but can be highly customized
  - [x] How other nostr: URLs should be displayed - links to an external site or internal pages?

